### PR TITLE
ターミナルでも有効な色設定を追加しました

### DIFF
--- a/syntax/tweetvim.vim
+++ b/syntax/tweetvim.vim
@@ -61,28 +61,23 @@ syntax match tweetvim_appendix_block /\]\]/ contained conceal
 "highlight uiki_title2 guifg=orange
 
 "highlight uiki_strong guifg=#FF80FF
-highlight tweetvim_title guifg=#bde682
-highlight tweetvim_status_id  guifg=#444444
-highlight tweetvim_created_at guifg=gray
-highlight tweetvim_screen_name guifg=#bde682
-highlight tweetvim_at_screen_name guifg=#bde682
-highlight tweetvim_link guifg=#80a0ff
 
-highlight tweetvim_hash_tag guifg=yellow
-
-highlight tweetvim_separator guifg=#444444
-highlight tweetvim_separator_title guifg=#444444
-highlight tweetvim_new_separator guifg=orange gui=undercurl
-
-highlight tweetvim_star guifg=yellow
-highlight tweetvim_reload guifg=orange
-highlight tweetvim_rt_count guifg=orange
-highlight tweetvim_rt_over  guifg=orange
-
-"highlight tweetvim_reply gui=underline
-highlight tweetvim_reply guifg=orange
-
-highlight tweetvim_appendix guifg=#616161
+hi def link tweetvim_title           Title
+hi def link tweetvim_status_id       Special
+hi def link tweetvim_created_at      NonText
+hi def link tweetvim_screen_name     String
+hi def link tweetvim_at_screen_name  String
+hi def link tweetvim_link            Underlined
+hi def link tweetvim_hash_tag        Constant
+hi def link tweetvim_separator       Ignore
+hi def link tweetvim_separator_title Ignore
+hi def link tweetvim_new_separator   Conditional
+hi def link tweetvim_star            Conditional
+hi def link tweetvim_reload          Constant
+hi def link tweetvim_rt_count        Question
+hi def link tweetvim_rt_over         Question
+hi def link tweetvim_reply           Delimiter
+hi def link tweetvim_appendix        Comment
 
 let b:current_syntax = 'tweetvim'
 


### PR DESCRIPTION
思い切って既存の highlight を削除し、hi def link ですべて置き換えてみました。

新方式::
- どんな colorscheme でもそれなりの見た目。
- 背景の明るい日でも安心。

旧方式::
- wombat, desert, xorium 等々、背景の暗い colorscheme にベストフィット。
- autumn, papayawhip, calmar256-light 等々、背景の明るい colorscheme ではさらに目が痛くなる。

&t_Co の値によって、既存の highlight と切り替えた方がいいかもしれません。
この辺はお任せします。
