### PR TITLE
subtract width when not only 'se nu' but also 'se rnu'

### DIFF
--- a/autoload/tweetvim/util.vim
+++ b/autoload/tweetvim/util.vim
@@ -46,7 +46,7 @@ endfunction
 "
 function! tweetvim#util#bufwidth()
   let width = winwidth(0)
-  if &l:number
+  if &l:number || &l:relativenumber
     let width = width - (&numberwidth + 1)
   endif
   return width


### PR DESCRIPTION
`:set relativenumber` なときに余分な空行が出来てしまいます。
