### PR TITLE
RT されたツイートが長すぎるときに末尾が ... で省略されてしまう問題の修正

### DIFF
--- a/autoload/tweetvim/buffer.vim
+++ b/autoload/tweetvim/buffer.vim
@@ -311,7 +311,9 @@ function! s:format(tweet, ...)
           \ }
   endif
 
-  let text = tweet.text
+  let text = has_key(tweet, 'retweeted_status')
+              \ ? 'RT @' . tweet.retweeted_status.user.screen_name . ': ' . tweet.retweeted_status.text
+              \ : tweet.text
   let text = substitute(text , '' , '' , 'g')
   let text = substitute(text , '\n' , '' , 'g')
   let text = tweetvim#util#unescape(text)


### PR DESCRIPTION
API から返ってくる RT のテキスト本文 a:tweet.text は長すぎると省略されていますが，
それに付随する RT 元のステータス情報 a:tweet.retweeted_status.text では
省略されていないので，そちらを使うように修正しました．
