### PR TITLE
t.co の自動展開

### DIFF
--- a/autoload/tweetvim.vim
+++ b/autoload/tweetvim.vim
@@ -69,8 +69,9 @@ endfunction
 "
 function! tweetvim#request(method, args)
   let args  = type(a:args) == 3 ? a:args : [a:args]
-  let param = {'per_page' : g:tweetvim_tweet_per_page, 
-              \'count'    : g:tweetvim_tweet_per_page}
+  let param = {'per_page' : g:tweetvim_tweet_per_page,
+              \'count'    : g:tweetvim_tweet_per_page,
+              \'include_entities' : 1}
   let param.include_rts = get(g:, 'tweetvim_include_rts', 1)
   let args  = s:merge_params(args, param)
 

--- a/autoload/tweetvim/buffer.vim
+++ b/autoload/tweetvim/buffer.vim
@@ -304,6 +304,17 @@ endfunction
 function! s:bufnr(buf_name)
   return bufexists(substitute(substitute(a:buf_name, '[', '\\[', 'g'), ']', '\\]', 'g') . '$')
 endfunction
+
+function! s:expand_t_co(text, status)
+  let text = a:text
+  if has_key(a:status, 'entities') && !empty(a:status.entities.urls)
+    for u in a:status.entities.urls
+      let text = substitute(text, '\M' . u.url, u.expanded_url, 'g')
+    endfor
+  endif
+  return text
+endfunction
+
 "
 "
 "
@@ -323,6 +334,8 @@ function! s:format(tweet, ...)
   let text = has_key(tweet, 'retweeted_status')
               \ ? 'RT @' . tweet.retweeted_status.user.screen_name . ': ' . tweet.retweeted_status.text
               \ : tweet.text
+  let text = s:expand_t_co(text,
+              \ has_key(tweet, 'retweeted_status') ? tweet.retweeted_status : tweet)
   let text = substitute(text , '' , '' , 'g')
   let text = substitute(text , '\n' , '' , 'g')
   let text = tweetvim#util#unescape(text)


### PR DESCRIPTION
　夜フクロウなどの多くのクライアントで標準装備されている t.co の自動展開機
能を実装しました．
　Twitter API はオプションに include_entities=1 を付けて送ると t.co による
短縮前の URL と短縮後の URL のペアの情報を status.entities.urls 内に付属し
て くれるので，それを利用 して t.co の URL を展開しています．
　ただ，稀に include_entities=1 でリクエストしても entities.urls が空のこ
とがある（Twitter API のバグっぽい）ので，その場合は展開できずそのままにな
ります．
