### PR TITLE
Fixed function name

### DIFF
--- a/plugin/tweetvim.vim
+++ b/plugin/tweetvim.vim
@@ -64,7 +64,7 @@ endif
 "
 command! TweetVimVersion :echo tweetvim#version()
 "
-command! TweetVimAccessToken  :call tweetvim#access_token()
+command! TweetVimAccessToken  :call tweetvim#account#access_token()
 "
 command! TweetVimHomeTimeline :call tweetvim#timeline('home_timeline')
 "


### PR DESCRIPTION
`:TweetVimAccessToken` doesn't work.

I renamed the function called by `:TweetVimAccessToken` to `tweetvim#account#access_token()` from `tweetvim#access_token()`.
