### PR TITLE
ignore withheld content

### DIFF
--- a/autoload/tweetvim.vim
+++ b/autoload/tweetvim.vim
@@ -190,7 +190,7 @@ endfunction
 function! s:flush_tweet(tweet)
   let tweet = a:tweet
   try
-    if has_key(tweet, 'friends') || has_key(tweet, 'delete') || has_key(tweet, 'event') || has_key(tweet,'disconnect')
+    if has_key(tweet, 'friends') || has_key(tweet, 'delete') || has_key(tweet, 'event') || has_key(tweet,'disconnect') || has_key(tweet, 'status_withheld') || has_key(tweet,'user_withheld')
       return
     endif
     let isbottom = line(".") == line("$")


### PR DESCRIPTION
https://dev.twitter.com/docs/streaming-apis/messages#Withheld_content_notices_status_withheld_user_withheld
を無視するようにしました。
ここ数日で頻繁にこれ由来のerrorがでるようになったんですがなぜだろう…
