### PR TITLE
disallow white spaces in hash tags

### DIFF
--- a/syntax/tweetvim.vim
+++ b/syntax/tweetvim.vim
@@ -22,7 +22,7 @@ syntax match tweetvim_at_screen_name "@[0-9A-Za-z_]\+"
 "syntax match tweetvim_link "\<https\?://[0-9A-Za-z_#?~=\-+%]+"
 syntax match tweetvim_link "https\?://[0-9A-Za-z_#?~=\-+%\.\/:]\+"
 
-syntax match tweetvim_hash_tag "[ 　。、]\zs[#＃][^ ].\{-1,}\ze[ \n]"
+syntax match tweetvim_hash_tag "[ 　。、]\zs[#＃]\S\+"
 
 syntax match tweetvim_separator       "^-\+$"
 syntax match tweetvim_separator_title "^\~\+$"


### PR DESCRIPTION
ハッシュタグ後もツイートが続くとそれらが全部ハッシュタグとしてハイライトされてしまうので，ハッシュタグ中で空白を許さないようにしました。本当は記号類も半角/全角問わず許されないものが多くありますが，調べるのが面倒なので取り急ぎ．
