### PR TITLE
Ignored case on highlighting reply names

### DIFF
--- a/autoload/tweetvim/buffer.vim
+++ b/autoload/tweetvim/buffer.vim
@@ -595,7 +595,7 @@ function! s:apply_syntax()
     return
   endif
   let screen_name = tweetvim#account#current().screen_name
-  execute 'syntax match tweetvim_reply "\zs.*@' . screen_name . '.\{-}\ze\s\[\["'
+  execute 'syntax match tweetvim_reply "\zs.*\c@' . screen_name . '.\{-}\ze\s\[\["'
   execute 'syntax match tweetvim_reply "\zs.* : ★ by .*\ze"'
 endfunction
 


### PR DESCRIPTION
自分への @ 付きリプライがハイライトされますが，リプライ先のスクリーン名は大文字小文字を区別しないようなので，ハイライトも大文字小文字を区別せずにするようにしました．
