### PR TITLE
Did refactorings and a tiny fix for syntax

### DIFF
--- a/syntax/tweetvim.vim
+++ b/syntax/tweetvim.vim
@@ -14,15 +14,15 @@ syntax match tweetvim_title "^\[.*" contains=tweetvim_reload
 syntax match tweetvim_status_id "\[\d\{-1,}\]$" display
 "syntax match tweetvim_created_at "- .\{-1,} \[" 
 "
-syntax match tweetvim_screen_name "^\s\=[0-9A-Za-z_]\{-1,} " display
+syntax match tweetvim_screen_name "^\s\=\w\{-1,} " display
 
-syntax match tweetvim_at_screen_name "@[0-9A-Za-z_]\+" display
+syntax match tweetvim_at_screen_name "@\w\+" display
 
 "syntax match tweetvim_link "\<https\?://\S\+"
-"syntax match tweetvim_link "\<https\?://[0-9A-Za-z_#?~=\-+%]+"
-syntax match tweetvim_link "\<https\?://[0-9A-Za-z_#?~=\-+%\.\/:]\+" display
+"syntax match tweetvim_link "\<https\?://[[:alnum:]_#?~=\-+%]+"
+syntax match tweetvim_link "\<https\?://[[:alnum:]_#?~=\-+%\.\/:@]\+" contains=NONE display
 
-syntax match tweetvim_hash_tag "[ 　。、]\zs[#＃]\S\+" display
+syntax match tweetvim_hash_tag "[ 　。、，．]\zs[#＃]\S\+" display
 
 syntax match tweetvim_separator       "^-\+$" display
 syntax match tweetvim_separator_title "^\~\+$" display
@@ -31,7 +31,6 @@ syntax match tweetvim_star " ★ " display
 syntax match tweetvim_reload "\[reload\]"
 
 syntax match tweetvim_rt_count " [0-9]\+RT\>" display
-syntax match tweetvim_rt_over  "'100+'RT\>" display
 
 syntax region tweetvim_appendix  start="\[\$" end="\$\]" contains=tweetvim_appendix_value display
 syntax match tweetvim_appendix_value "\[\$\zs.*\ze\$\]" display


### PR DESCRIPTION
- 正規表現に `\w` と `[:alnum:]` を使いました．こちらのほうが高速です．
- `100+RT` は RT 数が 100 までしかカウントできなかった頃の名残だと思うので削除しました．
- URL に利用できる文字として `@` が入っていなかったので追加しました．（例えば [Qiita の URL などで使われています](http://qiita.com/kaiinui@github/items/2781219340d427543d08)）

:dog2:
