### PR TITLE
Improved error message output on reload

### DIFF
--- a/autoload/tweetvim/action/reload.vim
+++ b/autoload/tweetvim/action/reload.vim
@@ -31,7 +31,9 @@ function! tweetvim#action#reload#execute(tweet)
     let ret   = call('tweetvim#timeline', [b:tweetvim_method] + b:tweetvim_args)
     
   catch
-    echo v:exception
-    echohl ErrorMsg | echo 'can not reload' | echohl None
+    echohl ErrorMsg
+    echomsg v:exception . " in " . v:throwpoint
+    echomsg 'can not reload'
+    echohl None
   endtry
 endfunction


### PR DESCRIPTION
稀にリロード時に `E114` や `E720` が出ることがあるのですが，throw point が分からない上ログにも残らなくてデバッグできないので，ログに残して throw point も出すようにしました．
