### PR TITLE
sort completion candidates

### DIFF
--- a/autoload/tweetvim/complete.vim
+++ b/autoload/tweetvim/complete.vim
@@ -2,13 +2,13 @@
 "
 "
 function! tweetvim#complete#screen_name(argLead, cmdLine, cursorPos)
-  return join(tweetvim#cache#get('screen_name'), "\n")
+  return join(sort(tweetvim#cache#get('screen_name')), "\n")
 endfunction
 "
 "
 "
 function! tweetvim#complete#account(arglead, ...)
-  return join(map(tweetvim#account#users(), 'v:val.screen_name'), "\n")
+  return join(sort(map(tweetvim#account#users(), 'v:val.screen_name')), "\n")
 endfunction
 "
 "
@@ -17,7 +17,7 @@ function! tweetvim#complete#search(argLead, cmdLine, cursorPos)
   let list = tweetvim#cache#get('screen_name')
   let list = extend(list, tweetvim#cache#get('hash_tag'))
   let list = tweetvim#util#uniq(list)
-  return join(list, "\n")
+  return join(sort(list), "\n")
 endfunction
 "
 "
@@ -31,5 +31,5 @@ function! tweetvim#complete#list(argLead, cmdLine, cursorPos)
     endif
   endfor
 
-  return join(slugs, "\n")
+  return join(sort(slugs), "\n")
 endfunction


### PR DESCRIPTION
現在の補完だと補完候補の順序がばらばら（キャッシュに追加された順？）でいつ目的のユーザ名が補完されるか分からなかったため，補完候補をソートするようにしてみました．

ちなみに現在の補完の候補順序って何か意味のある順序になっているのでしょうか？もしそうならソートするのはオプショナルにするので教えて下さい．