### PR TITLE
機能追加: デフォルトハッシュタグを追加する

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -97,6 +97,19 @@ commands
 
     :TweetVimSearch tweetvim
 
+### デフォルトのハッシュタグを設定
+
+全てのツイートに自動的に追加されるハッシュタグの設定
+空白区切で複数選択可
+
+    :TweetVimDefaultHashtag #tweetvim
+
+### デフォルトのハッシュタグをなくす
+
+    :TweetVimDefaultHashtag Reset
+    :TweetVimDefaultHashtag
+
+
 定義済みバッファキーマップ
 --------------------------
 

--- a/autoload/tweetvim/complete.vim
+++ b/autoload/tweetvim/complete.vim
@@ -33,3 +33,10 @@ function! tweetvim#complete#list(argLead, cmdLine, cursorPos)
 
   return join(sort(slugs), "\n")
 endfunction
+"
+"
+"
+function! tweetvim#complete#default_hashtag(...)
+  let tags = tweetvim#cache#get('hash_tag')
+  return "Reset\n" . join(map(sort(tags), '"#" . v:val'), "\n")
+endfunction

--- a/autoload/tweetvim/say.vim
+++ b/autoload/tweetvim/say.vim
@@ -9,7 +9,7 @@ endfunction
 " say with opened buffer
 "
 function! tweetvim#say#open(...)
-  let text  = a:0 > 0 ? a:1 : ''
+  let text  = (a:0 > 0 ? a:1 . ' ' : '') . g:tweetvim_default_hashtag . ' '
   let param = a:0 > 1 ? a:2 : {}
   
   let bufnr = bufwinnr('tweetvim_say')
@@ -83,7 +83,7 @@ function! tweetvim#say#command(...)
     endif
   endif
   " post
-  call s:post_tweet(msg)
+  call s:post_tweet(msg . ' ' . g:tweetvim_default_hashtag)
 endfunction
 "
 " say from current line

--- a/autoload/tweetvim/say.vim
+++ b/autoload/tweetvim/say.vim
@@ -69,7 +69,13 @@ endfunction
 " say with command line
 "
 function! tweetvim#say#command(...)
-  let msg = a:0 ? a:1 : input('tweet : ')
+  if g:tweetvim_default_hashtag != ""
+    let s:input_prompt =  'tweet (' .  g:tweetvim_default_hashtag . '): '
+  else
+    let s:input_prompt =  'tweet: '
+  endif
+
+  let msg = (a:0 ? a:1 : input(s:input_desc))
   " check msg
   if msg == ''
     redraw | echo '' | return

--- a/doc/tweetvim.txt
+++ b/doc/tweetvim.txt
@@ -173,6 +173,21 @@ COMMANDS					*tweetvim-commands*
 :TweetVimCurrentLineSay				*:TweetVimCurrentLineSay*
 		tweet the current line in buffer.
 
+:TweetVimDefaultHashtag                         *:TweetVimDefaultHashtag*
+                set a default hashtag which automatically added to all tweets.
+                This affects both 'TweetVimCommandSay' and 'TweetVimSay'
+                but not 'TweetVimCurrentLineSay'
+
+                `:TweetVimDefaultHashtag <hashtag> <hashtag> ...`
+
+                You can unset it by giving 'Reset' or no args.
+
+                
+                `:TweetVimDefaultHashtag`
+                `:TweetVimDefaultHashtag Reset`
+
+
+
 :TweetVimClearIcon [{screen_name}]		*:TweetVimClearIcon*
 		delete icons under |g:tweetvim_config_dir| . '/ico'
 		if {screen name} is not given, delete all icons.
@@ -356,6 +371,11 @@ g:tweetvim_no_default_key_mappings		*g:tweetvim_no_default_key_mappings*
 g:tweetvim_buffer_name				*g:tweetvim_buffer_name*
 		a buffer name for tweetvim buffer.
 		default : [tweetvim]
+
+g:tweetvim_default_hashtag                      *g:tweetvim_default_hashtag*
+                default hashtags which will be automatically added to all tweets.
+                If it empty, this feature will be ignored.
+                default : ''
 
 ==============================================================================
 FILES						*tweetvim-files*

--- a/plugin/tweetvim.vim
+++ b/plugin/tweetvim.vim
@@ -89,6 +89,8 @@ command! TweetVimAddAccount call tweetvim#account#add()
 command! -nargs=* -bang TweetVimUserStream call tweetvim#userstream(<bang>0, <f-args>)
 " clear icons from ~/.tweetvim/ico
 command! -nargs=? TweetVimClearIcon call tweetvim#util#clear_icon(<f-args>)
+" Set/Reset default hashtag
+command! -nargs=* -complete=custom,tweetvim#complete#default_hashtag TweetVimDefaultHashtag let g:tweetvim_default_hashtag = empty("<args>") || "<args>" =~ "^Reset.*" ? '' : "<args>"
 
 if globpath(&runtimepath, 'autoload/bitly.vim') != ''
   command! TweetVimBitly :call <SID>shorten_url()

--- a/plugin/tweetvim.vim
+++ b/plugin/tweetvim.vim
@@ -47,6 +47,7 @@ call s:set_global_variable('tweetvim_no_default_key_mappings', 0)
 call s:set_global_variable('tweetvim_empty_separator'        , 0)
 call s:set_global_variable('tweetvim_reconnect_seconds'      , 500)
 call s:set_global_variable('tweetvim_tweet_limit'            , 140)
+call s:set_global_variable('tweetvim_default_hashtag'        , '')
 
 if !isdirectory(g:tweetvim_config_dir)
   call mkdir(g:tweetvim_config_dir, 'p')


### PR DESCRIPTION
# 概要

設定している間に呟かれた全てのツイートに、自動的にハッシュタグ(デフォルトハッシュタグ)をつけて投稿する機能です。
デフォルトハッシュタグとして登録されたハッシュタグはツイートする際に明示されるため、「うっかりハッシュタグ付きでツイートしてしまった」事態は防げます。(詳しくは後述)



# 動機

LTやYoutubeライブなどの専用のハッシュタグを使うイベントの際、毎回ハッシュタグ手打ちしてツイートするのは面倒だし、コピペも間違えやすい。
そこで、「じゃあデフォルトで追加してくれればいいじゃん」ということで実装した機能です。


# 具体的な仕様

## 追加したもの

追加されたのは一つのコマンドと一つのオプションです。

  - `:TweetVimDefaultHashtag`
  - `g:tweetvim_default_hashtag`

### `:TweetVimDefaultHashtag`

このコマンドを使用してデフォルトハッシュタグの設定を行います。
(中身は`g:tweetvim_default_hashtag`をいじっているだけなので直接手で行うことも可能です。)

```vim
:TweetVimDefaultHashtag #tweetvim
" '#tweetvim' というハッシュタグをデフォルトハッシュタグとして設定する
:TweetVimDefaultHashtag #tweetvim #vim
" 複数のハッシュタグを設定することも可能です
:TweetVimDefaultHashtag
:TweetVimDefaultHashtag Reset
" 上記二通りの方法でデフォルトハッシュタグを削除できます
" 具体的には、`g:tweetvim_default_hashtag = ''`となります
```


また、コマンドライン補完として`tweetvim#complete#default_hashtag()`を追加しました。
これにより、引数を`Reset`およびキャッシュされたハッシュタグ名から補完可能です。


### `g:tweetvim_default_hashtag`

デフォルトハッシュタグとして使用する文字列が格納されます。
空の文字列の場合、デフォルトハッシュタグはツイートに一切追加されません。
また、デフォルトでは空(=何も追加されない)です。

## 変更したもの

### `tweetvim#say#command`

`tweetvim#say#command`で表示されるプロンプト(`tweet:`)を変更しました。

  - 通常時(デフォルトハッシュタグなし): `tweet: `   (変更なし)
  - デフォルトハッシュタグ付き(`#tweetvim`と`#vim`を設定したとすると): `tweet(#tweetvim #vim): `

これにより、デフォルトハッシュタグの存在を忘れてツイートされることがなくなります。
ちなみに、`s:post_tweet`に内容を渡す前に追加しているため、文字数超過にも気づけます。

### `tweetvim#say#open`


デフォルトハッシュタグがある場合、バッファの先頭に挿入します。
`tweetvim#say#open`に引数としてテキストが渡されている場合、そのテキストの後ろに追加します。


---

### 追記

途中で`g:tweetvim_footer`の存在に気づいたのですが、使おうとしたところうまく動かなかったこと、`TweetVimCommandSay`から使いたかったことなどから新しく作りました。